### PR TITLE
Style tweaks: Typography + cards

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -7,6 +7,7 @@
   --doc-sidebar-width: 220px !important;
 
   --grafana-colors-text-primary: rgb(204, 204, 220);
+  --grafana-colors-background-canvas: #111217;
   --grafana-colors-background-primary: #181b1f;
   --grafana-colors-background-secondary: #22252b;
   --grafana-colors-border-weak: rgba(204, 204, 220, 0.07);
@@ -163,16 +164,11 @@
 }
 
 main {
-  background: #111217;
+  background: var(--grafana-colors-background-canvas);
   color: var(--grafana-colors-text-primary);
 }
 
 /* ABOUT */
-
-#about {
-  /* background: #111217; */
-  /* font-weight: 300; */
-}
 
 #about #content {
   padding: 35px;
@@ -280,7 +276,7 @@ main {
 }
 
 #footer {
-  background: #111217;
+  background: var(--grafana-colors-background-canvas);
   font-size: 15px;
   padding: 20px 0;
   display: flex;


### PR DESCRIPTION
Few minor style tweaks to fix typography to look more like Grafana

 - Add a select few css variables for tokens from grafana's dark theme.
 - Set body text color to `colors.text.primary`
 - Set body font weight back to default regular
 - Change about cards/box background color to `colors.background.primary`
 - And some other card changes because I couldnt help myself (i can undo these if wanted - im not too precious about them)
    - Use body text size inside small cards (Foundations, Concepts, etc)
    - Remove 4px margin around the small cards
    - Increase the small cards padding from 14px to 24px
    - Decrease the big box (Overview, How Saga works, etc) padding from 32px to 24px so the text aligns with the small cards

### Before

![4621_2023-01-31-17-30_firefox](https://user-images.githubusercontent.com/46142/215844904-9737de10-c2e9-45a6-a2e1-73928b91cf19.png)

### After

![4622_2023-01-31-17-30_firefox](https://user-images.githubusercontent.com/46142/215844934-0e60440e-e313-4d51-ab5e-08a8c30285b2.png)

