### PR TITLE
Saga: Remove spacings that make mdx think these are code blocks

### DIFF
--- a/docs/01-about.mdx
+++ b/docs/01-about.mdx
@@ -39,7 +39,6 @@ import Link from '@docusaurus/Link';
         <div class='text'>Learn how to design, build, and expand the UI of Grafana without diverging.</div>
       </div>
     </div>
-
     <div id='box'>
       <div class='section'>
         <h2>Overview</h2>
@@ -78,7 +77,6 @@ import Link from '@docusaurus/Link';
         </ul>
       </div>
     </div>
-
     <h1>Resources</h1>
     <div id='cards-large'>
       <div class='card'>
@@ -106,7 +104,6 @@ import Link from '@docusaurus/Link';
         </div>
       </div>
     </div>
-
     <div id='box' class='footer'>
       <h2>Want to contribute?</h2>
       <p>Our design system is never complete, it’s constantly changing and evolving. We need help from Grafanistas like you to innovate and solve problems! Read this page to learn how you can contribute — we would love your help!</p>


### PR DESCRIPTION
Mdx is recognizing each of these spacings as the start of a new code block, so we need to remove them.