### PR TITLE
LivePreview: Add copy code button

### DIFF
--- a/src/theme/Playground/index.tsx
+++ b/src/theme/Playground/index.tsx
@@ -1,11 +1,13 @@
 import React, { PropsWithChildren } from 'react';
 import clsx from 'clsx';
 import useIsBrowser from '@docusaurus/useIsBrowser';
-import { LiveProvider, LiveEditor, LiveError, LivePreview, LiveProviderProps } from 'react-live';
+import { LiveProvider, LiveEditor, LiveError, LivePreview } from 'react-live';
 import Translate from '@docusaurus/Translate';
 import BrowserOnly from '@docusaurus/BrowserOnly';
 import { usePrismTheme } from '@docusaurus/theme-common';
-import type { Props as BaseProps } from '@theme/CodeBlock';
+import type { Props as PlaygroundProps } from '@theme/Playground';
+import CopyButton from '@theme/CodeBlock/CopyButton';
+
 import styles from './styles.module.css';
 
 function Header({ children }: PropsWithChildren) {
@@ -45,36 +47,33 @@ function ThemedLiveEditor() {
   );
 }
 
-function EditorWithHeader() {
+interface EditorWithHeaderProps {
+  code: string;
+}
+
+function EditorWithHeader({ code }: EditorWithHeaderProps) {
   return (
-    <>
+    <div className={styles.codeContainer}>
       <Header>
         <Translate id="theme.Playground.liveEditor" description="The live editor label of the live codeblocks">
           Live Editor
         </Translate>
       </Header>
-
+      <CopyButton code={code} className={styles.copyButton} />
       <ThemedLiveEditor />
-    </>
+    </div>
   );
 }
 
-// The import of Props from @theme/Playground is not resolved properly, so the types are copied here
-type CodeBlockProps = Omit<BaseProps, 'className' | 'language' | 'title'>;
-
-export interface Props extends CodeBlockProps, LiveProviderProps {
-  children: string;
-}
-
-export default function Playground({ children, transformCode, ...props }: Props) {
+export default function Playground({ children, transformCode, ...props }: PlaygroundProps) {
   const prismTheme = usePrismTheme();
   const noInline = props.metastring?.includes('noInline') ?? false;
-
+  const code = children.replace(/\n$/, '');
   return (
     <div className={styles.playgroundContainer}>
       {/* @ts-expect-error: type incompatibility with refs */}
       <LiveProvider
-        code={children.replace(/\n$/, '')}
+        code={code}
         noInline={noInline}
         theme={prismTheme}
         language="tsx"
@@ -91,7 +90,7 @@ export default function Playground({ children, transformCode, ...props }: Props)
         {...props}
       >
         <ResultWithHeader />
-        <EditorWithHeader />
+        <EditorWithHeader code={code} />
       </LiveProvider>
     </div>
   );

--- a/src/theme/Playground/styles.module.css
+++ b/src/theme/Playground/styles.module.css
@@ -66,3 +66,32 @@
   padding: 1rem;
   border: 1px solid var(--ifm-pre-background);
 }
+
+.codeContainer {
+  position: relative;
+
+  &:hover {
+    .copyButton {
+      opacity: 0.4;
+    }
+  }
+}
+
+button.copyButton {
+  position: absolute;
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+  z-index: 1;
+  opacity: 0;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 4px;
+
+  &:hover {
+    opacity: 1 !important;
+  }
+
+  & > span {
+    display: inline-block;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "useUnknownInCatchVariables": true,
     "incremental": true,
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
-    "preserveSymlinks": true
+    "preserveSymlinks": true,
+    "types": ["@docusaurus/theme-live-codeblock"]
   },
   "exclude": ["node_modules", "build", ".docusaurus"]
 }


### PR DESCRIPTION
Add copy code button to the live preview and make it look consistent with the CodeBlock copy button.

**Screenshot:**

![Screenshot 2023-10-09 at 10 48 23](https://github.com/grafana/design-system/assets/8878045/4258f052-f9fd-4e97-baf1-7922bc4a1e83)


Fixes: https://github.com/grafana/design-system/issues/49