### PR TITLE
Saga: Fix button image

### DIFF
--- a/docs/05-Components/Buttons/Button.mdx
+++ b/docs/05-Components/Buttons/Button.mdx
@@ -62,7 +62,7 @@ Clickable elements that are used to trigger actions. Buttons communicate what ac
 
 <div>
 
-![Dont](/img/button.anatomy.a.png)
+![Dont](/img/button.anatomy.b.png)
 
 #### Icon Button
 


### PR DESCRIPTION
We are currently showing the same image for Button with label and without, this changes it to show the correct images.