### PR TITLE
Saga: Remove keywords from docs and fix some descriptions

### DIFF
--- a/docs/01-about/overview.mdx
+++ b/docs/01-about/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: Overview
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'overview', 'about']
 sidebar_position: 1
 hide_title: true
 hide_table_of_contents: true

--- a/docs/01-about/overview.mdx
+++ b/docs/01-about/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Overview
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'overview', 'about']
 sidebar_position: 1
 hide_title: true
 hide_table_of_contents: true

--- a/docs/01-about/roadmap.mdx
+++ b/docs/01-about/roadmap.mdx
@@ -2,16 +2,17 @@
 title: Roadmap
 description: Grafana Labs Roadmap
 sidebar_position: 2
-keywords: ['Grafana', 'Labs', 'roadmap', 'planning']
 hide_title: true
 ---
 
 import { Badge } from '@grafana/ui';
 
-# Roadmap 
+# Roadmap
+
 Here is an idea for what is coming up next for the Saga Design System. Plans are subject to change based on our user needs and feedback. Our full backlog can be found on [GitHub](https://github.com/orgs/grafana/projects/176/views/2)
 
 ## Q4 2023
+
 - Improve design system metrics
 - Identify and create page templates
 - New feature highlight pattern
@@ -19,6 +20,7 @@ Here is an idea for what is coming up next for the Saga Design System. Plans are
 - Add iconography on Saga
 
 ## Q3 2023
+
 - ~~Developing primitives layout components~~
 - ~~Create documentation for different input type components~~
 - ~~Review and update contribuition, accessibility, pattern and styling documentation~~

--- a/docs/02-contributing.mdx
+++ b/docs/02-contributing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Contributing
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'contributing']
 hide_title: true
 sidebar_position: 2
 ---

--- a/docs/02-contributing.mdx
+++ b/docs/02-contributing.mdx
@@ -1,7 +1,6 @@
 ---
 title: Contributing
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'contributing']
 hide_title: true
 sidebar_position: 2
 ---

--- a/docs/03-foundations/accessibility/accessibility-overview.mdx
+++ b/docs/03-foundations/accessibility/accessibility-overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: Accessibility overview
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'accessibility', 'foundation']
 hide_title: true
 ---
 

--- a/docs/03-foundations/accessibility/accessibility-overview.mdx
+++ b/docs/03-foundations/accessibility/accessibility-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Accessibility overview
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'accessibility', 'foundation']
 hide_title: true
 ---
 

--- a/docs/03-foundations/accessibility/accessibility-styleguide.mdx
+++ b/docs/03-foundations/accessibility/accessibility-styleguide.mdx
@@ -1,7 +1,6 @@
 ---
 title: Accessibility styleguide
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'accessibility', 'styleguide', 'foundation']
 hide_title: true
 ---
 

--- a/docs/03-foundations/accessibility/accessibility-styleguide.mdx
+++ b/docs/03-foundations/accessibility/accessibility-styleguide.mdx
@@ -1,7 +1,7 @@
 ---
 title: Accessibility styleguide
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'accessibility', 'styleguide', 'foundation']
 hide_title: true
 ---
 

--- a/docs/03-foundations/color.mdx
+++ b/docs/03-foundations/color.mdx
@@ -1,7 +1,6 @@
 ---
 title: Color
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'color', 'foundation']
 draft: true
 ---
 

--- a/docs/03-foundations/color.mdx
+++ b/docs/03-foundations/color.mdx
@@ -1,7 +1,7 @@
 ---
 title: Color
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'color', 'foundation']
 draft: true
 ---
 

--- a/docs/03-foundations/design-principles.mdx
+++ b/docs/03-foundations/design-principles.mdx
@@ -1,7 +1,7 @@
 ---
 title: Design Principles
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'design', 'principles', 'foundation']
 hide_title: true
 ---
 

--- a/docs/03-foundations/design-principles.mdx
+++ b/docs/03-foundations/design-principles.mdx
@@ -1,7 +1,6 @@
 ---
 title: Design Principles
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'design', 'principles', 'foundation']
 hide_title: true
 ---
 

--- a/docs/03-foundations/layout-and-spacing.mdx
+++ b/docs/03-foundations/layout-and-spacing.mdx
@@ -1,7 +1,6 @@
 ---
 title: Layout and Spacing
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'layout', 'spacing', 'foundation']
 draft: true
 ---
 

--- a/docs/03-foundations/layout-and-spacing.mdx
+++ b/docs/03-foundations/layout-and-spacing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Layout and Spacing
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'layout', 'spacing', 'foundation']
 draft: true
 ---
 

--- a/docs/03-foundations/typography.mdx
+++ b/docs/03-foundations/typography.mdx
@@ -1,7 +1,7 @@
 ---
 title: Typography
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'typography', 'foundation']
 draft: true
 ---
 

--- a/docs/03-foundations/typography.mdx
+++ b/docs/03-foundations/typography.mdx
@@ -1,7 +1,6 @@
 ---
 title: Typography
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'typography', 'foundation']
 draft: true
 ---
 

--- a/docs/03-foundations/voice-and-tone.mdx
+++ b/docs/03-foundations/voice-and-tone.mdx
@@ -1,7 +1,6 @@
 ---
 title: Voice and Tone
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'voice', 'tone', 'foundation']
 hide_title: true
 ---
 

--- a/docs/03-foundations/voice-and-tone.mdx
+++ b/docs/03-foundations/voice-and-tone.mdx
@@ -1,7 +1,7 @@
 ---
 title: Voice and Tone
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'voice', 'tone', 'foundation']
 hide_title: true
 ---
 

--- a/docs/04-styling/border-radius.mdx
+++ b/docs/04-styling/border-radius.mdx
@@ -1,7 +1,7 @@
 ---
 title: Border Radius
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'border', 'radius', 'styling']
 draft: false
 ---
 
@@ -19,10 +19,9 @@ This is the general border radius or `shape.radius.default`, has a definition of
 
 ![standard border radius](/img/shape.radius.default.png 'Visual depiction of standard border radius in Grafana's UI')
 
-### Pill Border Radius 
+### Pill Border Radius
 
-The pill border radius or `shape.radius.pill`, has a pixel definition of 9999px.  This styling occurs less often in Grafana's UI. Smaller UI elements, such as switches, use the pill radius for a smooth, clean edge around their rounded elements.
-
+The pill border radius or `shape.radius.pill`, has a pixel definition of 9999px. This styling occurs less often in Grafana's UI. Smaller UI elements, such as switches, use the pill radius for a smooth, clean edge around their rounded elements.
 
 <div style={{ display: "flex" }}>
 

--- a/docs/04-styling/border-radius.mdx
+++ b/docs/04-styling/border-radius.mdx
@@ -1,7 +1,6 @@
 ---
 title: Border Radius
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'border', 'radius', 'styling']
 draft: false
 ---
 

--- a/docs/04-styling/elevation.mdx
+++ b/docs/04-styling/elevation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Elevation
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'elevation', 'styling']
 draft: true
 ---
 

--- a/docs/04-styling/elevation.mdx
+++ b/docs/04-styling/elevation.mdx
@@ -1,7 +1,6 @@
 ---
 title: Elevation
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'elevation', 'styling']
 draft: true
 ---
 

--- a/docs/04-styling/spacing.mdx
+++ b/docs/04-styling/spacing.mdx
@@ -1,7 +1,6 @@
 ---
 title: Spacing
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'spacing', 'styling']
 draft: true
 ---
 

--- a/docs/04-styling/spacing.mdx
+++ b/docs/04-styling/spacing.mdx
@@ -1,7 +1,7 @@
 ---
 title: Spacing
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'spacing', 'styling']
 draft: true
 ---
 

--- a/docs/04-styling/styles-and-states.mdx
+++ b/docs/04-styling/styles-and-states.mdx
@@ -1,7 +1,6 @@
 ---
 title: Styles & States
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'states', 'styling']
 draft: true
 ---
 

--- a/docs/04-styling/styles-and-states.mdx
+++ b/docs/04-styling/styles-and-states.mdx
@@ -1,7 +1,7 @@
 ---
 title: Styles & States
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'states', 'styling']
 draft: true
 ---
 

--- a/docs/05-components/02-buttons/button.mdx
+++ b/docs/05-components/02-buttons/button.mdx
@@ -1,7 +1,6 @@
 ---
 title: Button
 description: Grafana Labs Button component
-keywords: ['Grafana', 'Labs', 'button', 'component']
 hide_title: true
 ---
 

--- a/docs/05-components/02-buttons/iconButton.mdx
+++ b/docs/05-components/02-buttons/iconButton.mdx
@@ -1,7 +1,6 @@
 ---
 title: IconButton
 description: Grafana Labs IconButton component
-keywords: ['Grafana', 'Labs', 'button', 'iconbutton', 'component']
 hide_title: true
 ---
 

--- a/docs/05-components/03-primitives/box.mdx
+++ b/docs/05-components/03-primitives/box.mdx
@@ -1,6 +1,5 @@
 ---
 title: Box
 description: Grafana Labs Box component
-keywords: ['Grafana', 'Labs', 'box', 'component']
 draft: true
 ---

--- a/docs/05-components/03-primitives/flex.mdx
+++ b/docs/05-components/03-primitives/flex.mdx
@@ -1,6 +1,5 @@
 ---
 title: Flex
 description: Grafana Labs Flex component
-keywords: ['Grafana', 'Labs', 'flex', 'component']
 draft: true
 ---

--- a/docs/05-components/03-primitives/grid.mdx
+++ b/docs/05-components/03-primitives/grid.mdx
@@ -1,6 +1,5 @@
 ---
 title: Grid
 description: Grafana Labs Grid component
-keywords: ['Grafana', 'Labs', 'grid', 'component']
 draft: true
 ---

--- a/docs/05-components/03-primitives/stack.mdx
+++ b/docs/05-components/03-primitives/stack.mdx
@@ -1,6 +1,5 @@
 ---
 title: Stack
 description: Grafana Labs Stack component
-keywords: ['Grafana', 'Labs', 'stack', 'component']
 draft: true
 ---

--- a/docs/05-components/alert.mdx
+++ b/docs/05-components/alert.mdx
@@ -1,7 +1,6 @@
 ---
 title: Alert
 description: Grafana Labs Alert component
-keywords: ['Grafana', 'Labs', 'alert', 'component']
 ---
 
 # Alert <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/overlays-alert-inlinebanner--basic'/>
@@ -15,9 +14,11 @@ Use Alerts to inform users of updates, changes, or issues. Providing users feedb
 ## Usage
 
 ### Task-Generated
+
 Task-generated Alerts are triggered based on the behaviours of the user and provide quick, direct feedback. This type of Alert should be placed closely to the area the user is actively working in.
 
 ### System-Generated
+
 System-generated Alerts are triggered by the system, unconnected to the actions of a user. Use these Alerts to provide explanation of system status or other events that have occurred elsewhere.
 
 ## Implementation / Options
@@ -25,50 +26,59 @@ System-generated Alerts are triggered by the system, unconnected to the actions 
 ### Content
 
 #### Title
+
 Titles in Alerts are required, always. They should be concise, human-focused and jargon free so users can easily understand them.
 
 #### Description
+
 Description copy is optional and should be used sparingly. Keep the description copy short and focused on the reason for the Alert and include possible solutions or paths forward to prevent users from being blocked.
 
 #### Content guidelines (how to write)
+
 It is important to always use simple and concise language when crafting messaging for Alerts. Avoid using jargon or system errors in the content of the Alerts. Provide users with a path forward or possible solution. For more recommendations on writing, view the [UX writing guidelines](https://grafana.com/docs/writers-toolkit/write/style-guide/ux-writing/).
 
 #### Severity
+
 There are four (4) different message types Alerts can have:
-- *Info* - Provide information to users, and don’t interrupt any current actions
-- *Success* - When any action is successful, it is confirmed when a task is completed as expected
-- *Warning* - Informing users that an action is undesirable
-- *Error* - When an action doesn't happen as expected, usually something has failed and the user is expected to take action
+
+- _Info_ - Provide information to users, and don’t interrupt any current actions
+- _Success_ - When any action is successful, it is confirmed when a task is completed as expected
+- _Warning_ - Informing users that an action is undesirable
+- _Error_ - When an action doesn't happen as expected, usually something has failed and the user is expected to take action
 
 #### Calls to Action
+
 Alerts (Inline Alerts specifically) can contain calls to action (CTAs), especially if there is an action a user can take remedy or correct the reason the Alert is being shown. When providing a CTA within an Alert be sure to keep the label concise and ensure the action the user can take is clear, and try to keep the labels short (a few words at most). See Grafana's [UX Writing guidelines](https://grafana.com/docs/writers-toolkit/write/style-guide/ux-writing/).
 
 ## Types and Behaviors
+
 Grafana uses Alert in two ways: Inline, and Toast. These two different types of Alerts have different purposes and behaviours. It’s important to understand the differences to make sure you use the right one.
 
 ### Inline
+
 Inline Alerts notify users of both system and user triggered events. They appear at the top or bottom of the main content area near where the user is actively working. This maintains context and supports understanding. These messages are task-generated and provide direct, contextual feedback.
 
 ```tsx live
-<Alert title='Inline alert'>
+<Alert title="Inline alert">
   <div>Child content that includes some alert details, like maybe what actually happened.</div>
 </Alert>
 ```
 
 ### Toast
+
 Toasts are temporary window elements used to display short messages; they appear in the top-right corner of the screen and can be dismissed by clicking the `X` or it will disappear after a few seconds
 
 ```tsx live
-<Alert title='Toast' elevated>
+<Alert title="Toast" elevated>
   <div>Child content that includes some alert details, like maybe what actually happened.</div>
 </Alert>
 ```
 
 #### Behavior
+
 - Toasts display for a short period of time
 - Contain a close `X` action so users can dismiss the Alert
 - If more than one displays at the same time, the most recent Alert is always displayed at the top. Older toasts stack in order under the most recent Alert.
-
 
 ## Further Reading & Sources
 
@@ -79,4 +89,4 @@ Toasts are temporary window elements used to display short messages; they appear
 
 ## Playground
 
-<ComponentEmbed path='/story/overlays-alert-toast--basic' />
+<ComponentEmbed path="/story/overlays-alert-toast--basic" />

--- a/docs/05-components/badge.mdx
+++ b/docs/05-components/badge.mdx
@@ -1,7 +1,6 @@
 ---
 title: Badge
 description: Grafana Labs Badge component
-keywords: ['Grafana', 'Labs', 'badge', 'component']
 draft: true
 ---
 

--- a/docs/05-components/card.mdx
+++ b/docs/05-components/card.mdx
@@ -1,7 +1,6 @@
 ---
 title: Card
 description: Grafana Labs Card component
-keywords: ['Grafana', 'Labs', 'card', 'component']
 draft: true
 ---
 

--- a/docs/05-components/checkbox.mdx
+++ b/docs/05-components/checkbox.mdx
@@ -1,7 +1,6 @@
 ---
 title: Checkbox
 description: Grafana Labs Checkbox component
-keywords: ['Grafana', 'Labs', 'checkbox', 'component']
 draft: true
 ---
 

--- a/docs/05-components/components-status.mdx
+++ b/docs/05-components/components-status.mdx
@@ -2,13 +2,12 @@
 title: Components status
 description: Grafana Labs Components Status
 sidebar_position: 1
-keywords: ['Grafana', 'Labs', 'component', 'status', 'Saga', 'Storybook', 'Figma']
 hide_title: true
 ---
 
 import { StatusTable } from '../../src/theme/StatusTable/index.tsx';
 import { ComponentsStatusInfo } from '../../src/theme/StatusTable/utils.ts';
 
-# Component Status <Badge text="draft" color="orange"></Badge> 
+# Component Status <Badge text="draft" color="orange"></Badge>
 
-<StatusTable componentsData={ComponentsStatusInfo}/>
+<StatusTable componentsData={ComponentsStatusInfo} />

--- a/docs/05-components/field.mdx
+++ b/docs/05-components/field.mdx
@@ -1,7 +1,6 @@
 ---
 title: Field
 description: Grafana Labs Field component
-keywords: ['Grafana', 'Labs', 'field', 'component']
 ---
 
 # Field <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/forms-field--horizontal-layout' />
@@ -9,13 +8,16 @@ keywords: ['Grafana', 'Labs', 'field', 'component']
 The Field component is a wrapper for handling form input elements, such as text inputs, switches, or other custom input components, within a form. It provides features like labelling, descriptions, validation states, and layout options.
 
 ## When to use
+
 The Field component is suitable for various scenarios where you need to incorporate form inputs into your React application. Some common use cases include:
+
 - Creating forms with labeled input elements.
 - Adding descriptions to help users understand the purpose of the input.
 - Applying validation and error messages to form fields.
 - Indicating loading or disabled states for input fields.
 
 ## Implementation / Options
+
 Note that the Field component will pass the `invalid`, `disabled` and `loading` props, unless they are `undefined`, to the child component, which will override those props if they are set on the child component.
 
 ```tsx live
@@ -25,19 +27,23 @@ Note that the Field component will pass the `invalid`, `disabled` and `loading` 
 ```
 
 ### Do's
+
 - Provide a meaningful label for the field to enhance accessibility.
 - Provide a description for the field to help users understand the purpose of the input.
 
 ### Don'ts
+
 - Use the `description` prop without also providing a label.
 - Use the `invalid` prop without also providing an error message.
 
 ### Validation
+
 Use the `invalid` prop to indicate that the input is invalid. This will add a red border to the input and display the error message provided in the `error` prop. For this to work, both the `invalid` and `error` props must be set.
 
 ### Loading
+
 Use the `loading` prop to indicate that the input is loading. This will add a spinner to the input.
 
 ## Playground
 
-<ComponentEmbed path='/story/forms-field--horizontal-layout' />
+<ComponentEmbed path="/story/forms-field--horizontal-layout" />

--- a/docs/05-components/file-dropzone.mdx
+++ b/docs/05-components/file-dropzone.mdx
@@ -1,7 +1,6 @@
 ---
 title: File Dropzone
 description: Grafana Labs File Dropzone component
-keywords: ['Grafana', 'Labs', 'file', 'dropzone', 'component']
 draft: true
 ---
 

--- a/docs/05-components/filter-pill.mdx
+++ b/docs/05-components/filter-pill.mdx
@@ -1,7 +1,6 @@
 ---
 title: Filter Pill
 description: Grafana Labs Filter Pill component
-keywords: ['Grafana', 'Labs', 'filter', 'pill', 'component']
 draft: true
 ---
 

--- a/docs/05-components/inline-field.mdx
+++ b/docs/05-components/inline-field.mdx
@@ -1,7 +1,6 @@
 ---
 title: Inline Field
 description: Grafana Labs Inline Field component
-keywords: ['Grafana', 'Labs', 'inline', 'field', 'component']
 draft: true
 ---
 

--- a/docs/05-components/input.mdx
+++ b/docs/05-components/input.mdx
@@ -1,7 +1,7 @@
 ---
 title: Input
 description: Grafana Labs Input component
-keywords: ['Grafana', 'Labs', 'inline', 'field', 'component']
+keywords: ['Grafana', 'Labs', 'input', 'component']
 ---
 
 # Input <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/forms-input--simple' />

--- a/docs/05-components/input.mdx
+++ b/docs/05-components/input.mdx
@@ -1,7 +1,6 @@
 ---
 title: Input
 description: Grafana Labs Input component
-keywords: ['Grafana', 'Labs', 'input', 'component']
 ---
 
 # Input <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/forms-input--simple' />

--- a/docs/05-components/interactive-table.mdx
+++ b/docs/05-components/interactive-table.mdx
@@ -1,7 +1,6 @@
 ---
 title: InteractiveTable
 description: Grafana Labs InteractiveTable component
-keywords: ['Grafana', 'Labs', 'table', 'component']
 hide_title: true
 ---
 

--- a/docs/05-components/modal.mdx
+++ b/docs/05-components/modal.mdx
@@ -1,7 +1,6 @@
 ---
 title: Modal
 description: Grafana Labs Modal component
-keywords: ['Grafana', 'Labs', 'modal', 'component']
 draft: true
 ---
 

--- a/docs/05-components/pagination.mdx
+++ b/docs/05-components/pagination.mdx
@@ -1,7 +1,6 @@
 ---
 title: Pagination
 description: Grafana Labs Pagination component
-keywords: ['Grafana', 'Labs', 'pagination', 'component']
 draft: true
 ---
 

--- a/docs/05-components/plugin-signature.mdx
+++ b/docs/05-components/plugin-signature.mdx
@@ -1,7 +1,6 @@
 ---
 title: Plugin Signature
 description: Grafana Labs Plugin Signature component
-keywords: ['Grafana', 'Labs', 'plugin', 'signature', 'component']
 draft: true
 ---
 

--- a/docs/05-components/radio-button-group.mdx
+++ b/docs/05-components/radio-button-group.mdx
@@ -1,7 +1,6 @@
 ---
 title: RadioButtonGroup
 description: Grafana Labs Radio Button Group component
-keywords: ['Grafana', 'Labs', 'radio', 'button', 'group', 'component']
 hide_title: true
 ---
 

--- a/docs/05-components/radio-button-group.mdx
+++ b/docs/05-components/radio-button-group.mdx
@@ -1,6 +1,6 @@
 ---
 title: RadioButtonGroup
-description: Grafana Labs Radio Button component
+description: Grafana Labs Radio Button Group component
 keywords: ['Grafana', 'Labs', 'radio', 'button', 'group', 'component']
 hide_title: true
 ---

--- a/docs/05-components/radio-button.mdx
+++ b/docs/05-components/radio-button.mdx
@@ -1,7 +1,7 @@
 ---
 title: RadioButtonList
-description: Grafana Labs Radio Button component
-keywords: ['Grafana', 'Labs', 'radio', 'button', 'component']
+description: Grafana Labs Radio Button List component
+keywords: ['Grafana', 'Labs', 'radio', 'button', 'list', 'component']
 hide_title: true
 draft: true
 ---

--- a/docs/05-components/radio-button.mdx
+++ b/docs/05-components/radio-button.mdx
@@ -1,7 +1,6 @@
 ---
 title: RadioButtonList
 description: Grafana Labs Radio Button List component
-keywords: ['Grafana', 'Labs', 'radio', 'button', 'list', 'component']
 hide_title: true
 draft: true
 ---

--- a/docs/05-components/select.mdx
+++ b/docs/05-components/select.mdx
@@ -1,7 +1,6 @@
 ---
 title: Select
 description: Grafana Labs Select component
-keywords: ['Grafana', 'Labs', 'select', 'component']
 ---
 
 # Select <Badge text='ready' color='green'></Badge> <a href='https://developers.grafana.com/ui/canary/index.html?path=/story/forms-select--basic' target='_blank' className='header-links'>Storybook <Icon name="external-link-alt"/> </a>
@@ -9,17 +8,19 @@ keywords: ['Grafana', 'Labs', 'select', 'component']
 The Select component is a customizable select input component that allows users to select one or more options from a dropdown list. It is built on top of the [react-select](https://react-select.com/) library.
 
 <iframe
-    src="https://developers.grafana.com/ui/canary/index.html?path=/story/forms-select--basic"
-    width="100%"
-    height="300px"
+  src="https://developers.grafana.com/ui/canary/index.html?path=/story/forms-select--basic"
+  width="100%"
+  height="300px"
 ></iframe>
 
 ## When to use
+
 This component is particularly useful when you have a large number of options to choose from. Additionally, consider using Select in favor of radio button components when you have more than 4 options to choose from.
 
 ## Types and Behaviors
 
 ### Basic Select
+
 The Select component can be used to create a basic select input that allows users to select one option from a dropdown list. The `isClearable` prop can be used to allow the selected value(s) to be cleared. The `isLoading` prop can be used to indicate that the select input is in a loading state.
 
 ```tsx live noInline
@@ -48,10 +49,11 @@ render(<Basic />);
 ```
 
 ### Multi Select
+
 The Select component can be configured to allow users to select multiple options from a dropdown list. The `isMulti` prop must be set to true to enable this behavior. The `maxVisibleValues` prop can be used to limit the number of selected values to display. The `showAllSelectedWhenOpen` prop can be used to display all selected values when the dropdown list is open.
 
-
 ### Async Select
+
 The Select component can be configured to allow users to select one or more options from a dropdown list that is populated asynchronously. The `loadOptions` prop must be set to a function that returns a promise that resolves to an array of options. The `defaultOptions` prop can be used to provide options that are displayed before the user starts typing. In this case the options will be loaded on component mount. The `cacheOptions` prop can be used to cache the options that are loaded asynchronously.
 
 ```tsx live noInline
@@ -72,12 +74,7 @@ const BasicSelectAsync = () => {
 
   return (
     <Container>
-      <AsyncSelect
-        loadOptions={loadAsyncOptions}
-        defaultOptions
-        value={value}
-        onChange={setValue}
-      />
+      <AsyncSelect loadOptions={loadAsyncOptions} defaultOptions value={value} onChange={setValue} />
     </Container>
   );
 };
@@ -149,4 +146,3 @@ const SelectWithIcon = () => {
 
 render(<SelectWithIcon />);
 ```
-

--- a/docs/05-components/switch.mdx
+++ b/docs/05-components/switch.mdx
@@ -1,7 +1,6 @@
 ---
 title: Switch
 description: Grafana Labs Switch component
-keywords: ['Grafana', 'Labs', 'switch', 'component']
 ---
 
 # Switch <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/forms-switch--controlled' />

--- a/docs/05-components/text-link.mdx
+++ b/docs/05-components/text-link.mdx
@@ -1,7 +1,7 @@
 ---
 title: TextLink
 description: Grafana Labs TextLink component
-keywords: ['Grafana', 'Labs', 'textLink', 'component']
+keywords: ['Grafana', 'Labs', 'text', 'link', 'component']
 hide_title: true
 ---
 

--- a/docs/05-components/text-link.mdx
+++ b/docs/05-components/text-link.mdx
@@ -1,7 +1,6 @@
 ---
 title: TextLink
 description: Grafana Labs TextLink component
-keywords: ['Grafana', 'Labs', 'text', 'link', 'component']
 hide_title: true
 ---
 

--- a/docs/05-components/text.mdx
+++ b/docs/05-components/text.mdx
@@ -1,7 +1,6 @@
 ---
 title: Text
 description: Grafana Labs Text component
-keywords: ['Grafana', 'Labs', 'text', 'component']
 hide_title: true
 ---
 

--- a/docs/05-components/textarea.mdx
+++ b/docs/05-components/textarea.mdx
@@ -1,7 +1,6 @@
 ---
 title: TextArea
 description: Grafana Labs TextArea Component
-keywords: ['Grafana', 'Labs', 'textarea', 'component']
 ---
 
 # TextArea <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/forms-textarea--basic' />

--- a/docs/05-components/toggletip.mdx
+++ b/docs/05-components/toggletip.mdx
@@ -1,7 +1,7 @@
 ---
 title: Toggletip
-description: Grafana Labs Badge component
-keywords: ['Grafana', 'Labs', 'toggleTip', 'component']
+description: Grafana Labs Toggletip component
+keywords: ['Grafana', 'Labs', 'toggletip', 'component']
 hide_title: true
 ---
 

--- a/docs/05-components/toggletip.mdx
+++ b/docs/05-components/toggletip.mdx
@@ -1,7 +1,6 @@
 ---
 title: Toggletip
 description: Grafana Labs Toggletip component
-keywords: ['Grafana', 'Labs', 'toggletip', 'component']
 hide_title: true
 ---
 

--- a/docs/05-components/tooltip.mdx
+++ b/docs/05-components/tooltip.mdx
@@ -1,7 +1,6 @@
 ---
 title: Tooltip
 description: Grafana Labs Tooltip component
-keywords: ['Grafana', 'Labs', 'tooltip', 'component']
 hide_title: true
 ---
 

--- a/docs/06-patterns/alert.mdx
+++ b/docs/06-patterns/alert.mdx
@@ -1,7 +1,7 @@
 ---
 title: Alert
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'alert', 'pattern']
 hide_title: true
 ---
 

--- a/docs/06-patterns/alert.mdx
+++ b/docs/06-patterns/alert.mdx
@@ -1,7 +1,6 @@
 ---
 title: Alert
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'alert', 'pattern']
 hide_title: true
 ---
 

--- a/docs/06-patterns/delete.mdx
+++ b/docs/06-patterns/delete.mdx
@@ -1,7 +1,6 @@
 ---
 title: Delete
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'delete', 'pattern']
 hide_title: true
 draft: true
 ---

--- a/docs/06-patterns/delete.mdx
+++ b/docs/06-patterns/delete.mdx
@@ -1,7 +1,7 @@
 ---
 title: Delete
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'delete', 'pattern']
 hide_title: true
 draft: true
 ---

--- a/docs/06-patterns/dialogues.mdx
+++ b/docs/06-patterns/dialogues.mdx
@@ -1,7 +1,7 @@
 ---
 title: Dialogues
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'dialogues', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/dialogues.mdx
+++ b/docs/06-patterns/dialogues.mdx
@@ -1,7 +1,6 @@
 ---
 title: Dialogues
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'dialogues', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/disabled-state.mdx
+++ b/docs/06-patterns/disabled-state.mdx
@@ -1,7 +1,6 @@
 ---
 title: Disabled State
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'disabled', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/disabled-state.mdx
+++ b/docs/06-patterns/disabled-state.mdx
@@ -1,7 +1,7 @@
 ---
 title: Disabled State
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'disabled', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/empty-state.mdx
+++ b/docs/06-patterns/empty-state.mdx
@@ -1,7 +1,6 @@
 ---
 title: Empty State
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'empty', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/empty-state.mdx
+++ b/docs/06-patterns/empty-state.mdx
@@ -1,7 +1,7 @@
 ---
 title: Empty State
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'empty', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/error-handling.mdx
+++ b/docs/06-patterns/error-handling.mdx
@@ -1,7 +1,6 @@
 ---
 title: Error Handling
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'error', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/error-handling.mdx
+++ b/docs/06-patterns/error-handling.mdx
@@ -1,7 +1,7 @@
 ---
 title: Error Handling
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'error', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/external-links.mdx
+++ b/docs/06-patterns/external-links.mdx
@@ -1,7 +1,6 @@
 ---
 title: External Links
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'external', 'links', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/external-links.mdx
+++ b/docs/06-patterns/external-links.mdx
@@ -1,7 +1,7 @@
 ---
 title: External Links
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'external', 'links', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/forms.mdx
+++ b/docs/06-patterns/forms.mdx
@@ -1,7 +1,6 @@
 ---
 title: Forms
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'forms', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/forms.mdx
+++ b/docs/06-patterns/forms.mdx
@@ -1,7 +1,7 @@
 ---
 title: Forms
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'forms', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/loading-state.mdx
+++ b/docs/06-patterns/loading-state.mdx
@@ -1,7 +1,7 @@
 ---
 title: Loading State
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'loading', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/loading-state.mdx
+++ b/docs/06-patterns/loading-state.mdx
@@ -1,7 +1,6 @@
 ---
 title: Loading State
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'loading', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/save.mdx
+++ b/docs/06-patterns/save.mdx
@@ -1,7 +1,6 @@
 ---
 title: Save
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'save', 'pattern']
 hide_title: true
 ---
 

--- a/docs/06-patterns/save.mdx
+++ b/docs/06-patterns/save.mdx
@@ -1,7 +1,7 @@
 ---
 title: Save
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'save', 'pattern']
 hide_title: true
 ---
 

--- a/docs/06-patterns/share.mdx
+++ b/docs/06-patterns/share.mdx
@@ -1,7 +1,6 @@
 ---
 title: Share
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'share', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/share.mdx
+++ b/docs/06-patterns/share.mdx
@@ -1,7 +1,7 @@
 ---
 title: Share
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'share', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/validation.mdx
+++ b/docs/06-patterns/validation.mdx
@@ -1,7 +1,7 @@
 ---
 title: Validation
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'validation', 'pattern']
 draft: true
 ---
 

--- a/docs/06-patterns/validation.mdx
+++ b/docs/06-patterns/validation.mdx
@@ -1,7 +1,6 @@
 ---
 title: Validation
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'validation', 'pattern']
 draft: true
 ---
 

--- a/docs/07-templates/01-overview.mdx
+++ b/docs/07-templates/01-overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: Overview
 description: Description for search engines and results
-keywords: ['template', 'overview']
 sidebar_position: 1
 hide_title: true
 hide_table_of_contents: true

--- a/docs/07-templates/form-page.mdx
+++ b/docs/07-templates/form-page.mdx
@@ -1,7 +1,6 @@
 ---
 title: Form Page
 description: Template for FormPage
-keywords: ['FormPage', 'template']
 hide_table_of_contents: true
 draft: true
 ---

--- a/docs/07-templates/grid-page.mdx
+++ b/docs/07-templates/grid-page.mdx
@@ -1,7 +1,6 @@
 ---
 title: Grid Page
 description: Template for Grid Page
-keywords: ['GridPage', 'template']
 hide_table_of_contents: true
 draft: true
 ---

--- a/docs/07-templates/list-page.mdx
+++ b/docs/07-templates/list-page.mdx
@@ -1,7 +1,6 @@
 ---
 title: List Page
 description: Template for List Page
-keywords: ['ListPage', 'template']
 hide_table_of_contents: true
 draft: true
 ---

--- a/docs/07-templates/table.mdx
+++ b/docs/07-templates/table.mdx
@@ -1,7 +1,6 @@
 ---
 title: Table Page
 description: Patterns for displaying tabular data
-keywords: ['table', 'template']
 hide_table_of_contents: true
 draft: true
 ---

--- a/docs/08-resources.mdx
+++ b/docs/08-resources.mdx
@@ -1,7 +1,6 @@
 ---
 title: Resources
 description: Description for search engines and results
-keywords: ['Grafana', 'Labs', 'resources']
 ---
 
 import { Badge } from '@grafana/ui';

--- a/docs/08-resources.mdx
+++ b/docs/08-resources.mdx
@@ -1,7 +1,7 @@
 ---
 title: Resources
 description: Description for search engines and results
-keywords: ['keywords', 'for', 'search', 'engines']
+keywords: ['Grafana', 'Labs', 'resources']
 ---
 
 import { Badge } from '@grafana/ui';

--- a/scripts/templates/component.mdx.hbs
+++ b/scripts/templates/component.mdx.hbs
@@ -1,7 +1,6 @@
 ---
 title: {{componentName}}
 description: Grafana Labs {{componentName}} component
-keywords: ['Grafana', 'Labs', '{{properCase componentName}}' , 'component']
 ---
 
 # {{componentName}} <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/overlays-alert-toast--basic'/>

--- a/scripts/templates/template.mdx.hbs
+++ b/scripts/templates/template.mdx.hbs
@@ -1,7 +1,6 @@
 ---
 title: {{templateName}}
 description: Template for {{templateName}}
-keywords: ['{{templateName}}', 'template']
 hide_table_of_contents: true
 draft: true
 ---


### PR DESCRIPTION
According to a lot of websites I read (i.e. [here](https://www.semrush.com/blog/meta-keywords/) or [here](https://ahrefs.com/blog/meta-keywords/)) keywords are no longer used by most search engines. So there is no point in having some more metadata to figure out how to write and I have removed them.

I have also fixed some component descriptions.

(all other changes were prettier changes when saving)