### PR TITLE
Saga: Add descriptions to every visible page

### DIFF
--- a/docs/01-about/overview.mdx
+++ b/docs/01-about/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Description for search engines and results
+description: Saga is the design system for Grafana Labs. It is a collection of styles, components, and guidelines used for creating consistent interfaces and experiences.
 sidebar_position: 1
 hide_title: true
 hide_table_of_contents: true

--- a/docs/01-about/roadmap.mdx
+++ b/docs/01-about/roadmap.mdx
@@ -1,6 +1,6 @@
 ---
 title: Roadmap
-description: Grafana Labs Roadmap
+description: This is the roadmap for the Saga Design System. Plans are subject to change based on our user needs and feedback. Our full backlog can be found on GitHub
 sidebar_position: 2
 hide_title: true
 ---

--- a/docs/02-contributing.mdx
+++ b/docs/02-contributing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Contributing
-description: Description for search engines and results
+description: Our design system is never complete, it’s constantly changing and evolving. We need help from Grafanistas like you to innovate and solve problems! Read this page to learn how you can contribute — we would love your help!
 hide_title: true
 sidebar_position: 2
 ---

--- a/docs/03-foundations/accessibility/accessibility-overview.mdx
+++ b/docs/03-foundations/accessibility/accessibility-overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Accessibility overview
-description: Description for search engines and results
+description: Grafana Labs is dedicated to improving our graphical user interfaces and overall experience so that our product becomes usable and accessible for people with disabilities as well as anyone else.
 hide_title: true
 ---
 

--- a/docs/03-foundations/accessibility/accessibility-styleguide.mdx
+++ b/docs/03-foundations/accessibility/accessibility-styleguide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Accessibility styleguide
-description: Description for search engines and results
+description: At Grafana we pay special attention to accessibility and that's why it's important that all components are written with it in mind.
 hide_title: true
 ---
 

--- a/docs/03-foundations/design-principles.mdx
+++ b/docs/03-foundations/design-principles.mdx
@@ -1,6 +1,6 @@
 ---
 title: Design Principles
-description: Description for search engines and results
+description: Design principles empower designers and developers across the organization to make design decisions in the same manner regardless of the decision makers.
 hide_title: true
 ---
 

--- a/docs/03-foundations/voice-and-tone.mdx
+++ b/docs/03-foundations/voice-and-tone.mdx
@@ -1,6 +1,6 @@
 ---
 title: Voice and Tone
-description: Description for search engines and results
+description: At Grafana, we like our company to sound like a real person.
 hide_title: true
 ---
 

--- a/docs/04-styling/border-radius.mdx
+++ b/docs/04-styling/border-radius.mdx
@@ -1,6 +1,6 @@
 ---
 title: Border Radius
-description: Description for search engines and results
+description: Rounded corners are mostly a stylistic choice to make the Grafana UI appear more modern, feel more friendly, and add extra sense of "polish" to the visual elements.
 draft: false
 ---
 

--- a/docs/05-components/02-buttons/button.mdx
+++ b/docs/05-components/02-buttons/button.mdx
@@ -1,6 +1,6 @@
 ---
 title: Button
-description: Grafana Labs Button component
+description: Clickable elements that are used to trigger actions. Buttons communicate what action will occur when users interact with it.
 hide_title: true
 ---
 

--- a/docs/05-components/02-buttons/iconButton.mdx
+++ b/docs/05-components/02-buttons/iconButton.mdx
@@ -1,6 +1,6 @@
 ---
 title: IconButton
-description: Grafana Labs IconButton component
+description: IconButtons are actionable buttons that only display an icon. Since there is no standard label, it's critical to include a tooltip with all IconButtons so the label can be accessed upon hover.
 hide_title: true
 ---
 

--- a/docs/05-components/alert.mdx
+++ b/docs/05-components/alert.mdx
@@ -1,6 +1,6 @@
 ---
 title: Alert
-description: Grafana Labs Alert component
+description: Alert is a fundamental element used for displaying important messages or notifications to users.
 ---
 
 # Alert <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/overlays-alert-inlinebanner--basic'/>

--- a/docs/05-components/field.mdx
+++ b/docs/05-components/field.mdx
@@ -1,6 +1,6 @@
 ---
 title: Field
-description: Grafana Labs Field component
+description: The Field component is a wrapper for handling form input elements, such as text inputs, switches, or other custom input components, within a form. It provides features like labelling, descriptions, validation states, and layout options.
 ---
 
 # Field <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/forms-field--horizontal-layout' />

--- a/docs/05-components/input.mdx
+++ b/docs/05-components/input.mdx
@@ -1,6 +1,6 @@
 ---
 title: Input
-description: Grafana Labs Input component
+description: A basic component that allows a user to write or edit text.
 ---
 
 # Input <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/forms-input--simple' />

--- a/docs/05-components/interactive-table.mdx
+++ b/docs/05-components/interactive-table.mdx
@@ -1,6 +1,6 @@
 ---
 title: InteractiveTable
-description: Grafana Labs InteractiveTable component
+description: The table is used to display and select data efficiently. The table component allows for the display and modification of detailed information. With additional functionality it allows for batch editing, as needed by your feature’s users.
 hide_title: true
 ---
 

--- a/docs/05-components/radio-button-group.mdx
+++ b/docs/05-components/radio-button-group.mdx
@@ -1,6 +1,6 @@
 ---
 title: RadioButtonGroup
-description: Grafana Labs Radio Button Group component
+description: RadioButtonGroup is used to select a single value from multiple mutually exclusive options using a horizontal tab-like layout.
 hide_title: true
 ---
 

--- a/docs/05-components/select.mdx
+++ b/docs/05-components/select.mdx
@@ -1,6 +1,6 @@
 ---
 title: Select
-description: Grafana Labs Select component
+description: The Select component is a customizable select input component that allows users to select one or more options from a dropdown list.
 ---
 
 # Select <Badge text='ready' color='green'></Badge> <a href='https://developers.grafana.com/ui/canary/index.html?path=/story/forms-select--basic' target='_blank' className='header-links'>Storybook <Icon name="external-link-alt"/> </a>

--- a/docs/05-components/switch.mdx
+++ b/docs/05-components/switch.mdx
@@ -1,6 +1,6 @@
 ---
 title: Switch
-description: Grafana Labs Switch component
+description: The Switch component is used to toggle between two states, typically representing an on/off or enabled/disabled state.
 ---
 
 # Switch <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/forms-switch--controlled' />

--- a/docs/05-components/text-link.mdx
+++ b/docs/05-components/text-link.mdx
@@ -1,6 +1,6 @@
 ---
 title: TextLink
-description: Grafana Labs TextLink component
+description: The TextLink component renders an anchor tag <a> that takes users to another page, external or internal to Grafana.
 hide_title: true
 ---
 

--- a/docs/05-components/text.mdx
+++ b/docs/05-components/text.mdx
@@ -1,6 +1,6 @@
 ---
 title: Text
-description: Grafana Labs Text component
+description: The Text component can be used to apply typography styles in a simple way, without the need for extra CSS.
 hide_title: true
 ---
 

--- a/docs/05-components/textarea.mdx
+++ b/docs/05-components/textarea.mdx
@@ -1,6 +1,6 @@
 ---
 title: TextArea
-description: Grafana Labs TextArea Component
+description: TextArea is a fundamental component used for capturing larger inputs from users, such as descriptions or detailed information.
 ---
 
 # TextArea <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/forms-textarea--basic' />

--- a/docs/05-components/toggletip.mdx
+++ b/docs/05-components/toggletip.mdx
@@ -1,6 +1,6 @@
 ---
 title: Toggletip
-description: Grafana Labs Toggletip component
+description: Toggletips, similar to Tooltips, provide contextual support for users when needed. They are hidden by default, a UI trigger or text link is clicked to set them to their visible state.
 hide_title: true
 ---
 

--- a/docs/05-components/tooltip.mdx
+++ b/docs/05-components/tooltip.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tooltip
-description: Grafana Labs Tooltip component
+description: Tooltips display additional information upon hover or focus. The information included should be contextual, helpful, and non-critical to the user’s task-at-hand.
 hide_title: true
 ---
 

--- a/docs/06-patterns/alert.mdx
+++ b/docs/06-patterns/alert.mdx
@@ -1,6 +1,6 @@
 ---
 title: Alert
-description: Description for search engines and results
+description: Alerts display important messages in a way that attracts the user's attention without interrupting their task.
 hide_title: true
 ---
 

--- a/docs/06-patterns/save.mdx
+++ b/docs/06-patterns/save.mdx
@@ -1,6 +1,6 @@
 ---
 title: Save
-description: Description for search engines and results
+description: Saving within Grafana is a multi-tiered pattern that varies depending on the required amount of friction and importance of the item being saved.
 hide_title: true
 ---
 

--- a/docs/08-resources.mdx
+++ b/docs/08-resources.mdx
@@ -1,6 +1,6 @@
 ---
 title: Resources
-description: Description for search engines and results
+description: Tools available to help designers and developers build better solutions with our Saga Design System.
 ---
 
 import { Badge } from '@grafana/ui';


### PR DESCRIPTION
Based on the suggestions made [here](https://docs.google.com/spreadsheets/d/1O6eS1ea56AdI3xAEnkIptYltnFzyZRwAiYRpbhcGAVg/edit#gid=0), add descriptions to every page that is visible on production.