### PR TITLE
Saga: Fix the capitalization of the redirect

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,5 +3,5 @@ import { Redirect } from 'react-router-dom';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 export default function Home() {
-  return <Redirect to={useBaseUrl('/About/overview')} />;
+  return <Redirect to={useBaseUrl('/about/overview')} />;
 }


### PR DESCRIPTION
If you go to https://grafana.com/developers/saga it is redirecting incorrectly to `/About/overview`, need to fix it to the new capitalization