### PR TITLE
Saga: Set node that is used for create tokens to 18

### DIFF
--- a/.github/workflows/create-tokens.yml
+++ b/.github/workflows/create-tokens.yml
@@ -2,7 +2,7 @@ name: Create Tokens
 on:
   push:
     paths:
-    - 'tokens/**'
+      - 'tokens/**'
 
 jobs:
   build:
@@ -12,6 +12,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'yarn'
       # Install dependencies
       - run: npm install
       # Transform Figma Tokens JSON to something Style Dictionary can read, run Style Dictionary


### PR DESCRIPTION
Copying the same node setup from the other actions that are not failing. Hopefully this fixes it.