### PR TITLE
Add an iconography page

### DIFF
--- a/docs/03-foundations/iconography.mdx
+++ b/docs/03-foundations/iconography.mdx
@@ -4,8 +4,6 @@ description: Description for search engines and results
 draft: true
 ---
 
-import { Badge } from '@grafana/ui';
-
 # Iconography <Badge text='draft' color='orange'></Badge>
 
 This document is a WIP.

--- a/docs/03-foundations/iconography.mdx
+++ b/docs/03-foundations/iconography.mdx
@@ -1,0 +1,15 @@
+---
+title: Iconography
+description: Description for search engines and results
+draft: true
+---
+
+import { Badge } from '@grafana/ui';
+
+# Iconography <Badge text='draft' color='orange'></Badge>
+
+This document is a WIP.
+
+## Contributing new icons
+
+See the [icon README](https://github.com/grafana/grafana/blob/main/public/img/icons/README.md) for instructions on how to contribute new icons.


### PR DESCRIPTION
follow up to https://github.com/grafana/grafana/pull/81371
- creates a draft `Iconography` page
- links to the contributing docs in github

leaves the rest blank because i don't know what to write there 😂 