### PR TITLE
Fixing link root to writer's toolkit

### DIFF
--- a/docs/05-components/text-link.mdx
+++ b/docs/05-components/text-link.mdx
@@ -116,7 +116,7 @@ The following is the default behaviour and will be applied according to its type
 
 ## Further Reading & Sources
 
-- [Writers Toolkit: Write useful link text](https://grafana.com/docs/writers-toolkit/writing-guide/useful-link-text/)
+- [Writers Toolkit: Write useful link text](https://grafana.com/docs/writers-toolkit/write/links/useful-link-text/)
 - [Accessibility: WCAG | Link purpose in content](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html)
 
 ## Playground


### PR DESCRIPTION
The URL for writing link text was no longer up to date. Updated.