### PR TITLE
Saga website: Always use links with trailing slash for consistency

### DIFF
--- a/docs/05-components/toggletip.mdx
+++ b/docs/05-components/toggletip.mdx
@@ -6,7 +6,7 @@ hide_title: true
 
 # Toggletip <Badge text='ready' color='green'></Badge> <StorybookLink path="/story/overlays-toggletip--basic" />
 
-Toggletips, similar to [Tooltips](/Components/toggletip), provide contextual support for users when needed. They are hidden by default, a UI trigger or text link is clicked to set them to their visible state. Toggletips, unlike tooltips, are persistent until a user takes action to dismiss them by clicking on the required `X` (close) trigger.
+Toggletips, similar to [Tooltips](/components/tooltip), provide contextual support for users when needed. They are hidden by default, a UI trigger or text link is clicked to set them to their visible state. Toggletips, unlike tooltips, are persistent until a user takes action to dismiss them by clicking on the required `X` (close) trigger.
 
 ```tsx live
 <Toggletip
@@ -34,7 +34,7 @@ Toggletips reveal **supplemental content** when a user clicks a button or anothe
 ### Don'ts
 
 - Do not use if a user would be configuring, selecting, entering data, or editing content on a page through the toggletip.
-- Do not use when a [Tooltip](/Components/tooltip) with clarifying text would suffice.
+- Do not use when a [Tooltip](/components/tooltip) with clarifying text would suffice.
 - Do not house information critical to a user’s task completion.
 - Do not hide required information from a user to complete a task or workflow.
 - Do not use to surface actions to users.
@@ -80,7 +80,7 @@ Toggletips have two states.
 
 ## Related
 
-- [Tooltip](/Components/toggletip)
+- [Tooltip](/components/tooltip)
 
 ### Production Examples
 

--- a/docs/05-components/tooltip.mdx
+++ b/docs/05-components/tooltip.mdx
@@ -104,7 +104,7 @@ Tooltips are triggered when the mouse hovers over or focuses on the UI trigger. 
 
 ## Related
 
-If interactive elements are needed, consider using a **[ToggleTip](/Components/toggletip)**.
+If interactive elements are needed, consider using a **[ToggleTip](/components/toggletip)**.
 
 ### Further Reading & Sources
 

--- a/docs/06-patterns/delete.mdx
+++ b/docs/06-patterns/delete.mdx
@@ -9,7 +9,7 @@ import { Badge, InfoBox } from '@grafana/ui';
 
 # Delete <Badge text='draft' color='orange'></Badge>
 
-Deleting within Grafana is a multi-tiered pattern that varies based on the required amount of friction (see: [Design Principle: Tasteful Friction](/Foundations/design-principles#tasteful-friction)) and importance of the item being deleted.
+Deleting within Grafana is a multi-tiered pattern that varies based on the required amount of friction (see: [Design Principle: Tasteful Friction](/foundations/design-principles#tasteful-friction)) and importance of the item being deleted.
 
 # Tiers
 

--- a/docusaurus.config.base.js
+++ b/docusaurus.config.base.js
@@ -13,6 +13,7 @@ const baseConfig = {
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/logo.png',
   staticDirectories: ['static'],
+  trailingSlash: true,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,7 +5,6 @@ const config = {
   ...baseConfig,
   url: 'https://grafana.com',
   baseUrl: 'developers/saga/',
-  trailingSlash: true,
 
   themeConfig: {
     ...baseConfig.themeConfig,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -5,6 +5,7 @@ const config = {
   ...baseConfig,
   url: 'https://grafana.com',
   baseUrl: 'developers/saga/',
+  trailingSlash: true,
 
   themeConfig: {
     ...baseConfig.themeConfig,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,5 +3,5 @@ import { Redirect } from 'react-router-dom';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 export default function Home() {
-  return <Redirect to={useBaseUrl('/about/overview')} />;
+  return <Redirect to={useBaseUrl('/about/overview/')} />;
 }


### PR DESCRIPTION
For SEO reasons, we should be consistent in the use of trailing slashes, especially on the home page. This guarantees that all of our internal links use trailing slashes.
It doesn't accomplish the 301 redirect mentioned in https://github.com/grafana/grafana/issues/84667 , since that would probably need to be done on the nginx side, but would be good to discuss if this is enough to complete that task.

Also fixes some links that were still linking to capital letter URLs and pointing at the wrong pages.