### PR TITLE
Saga: Fix 2 broken links

### DIFF
--- a/docs/06-patterns/alert.mdx
+++ b/docs/06-patterns/alert.mdx
@@ -72,7 +72,7 @@ An Alert can contain a single action, dismiss or close actions are optional.
 
 ## Related
 
-- **[Banner Notification](/components/alert-banner)**
+- **[Alert Components](/components/alert/)**
 
 ### Further Reading & Sources
 

--- a/src/components/templates/MultistepFormPage/utils/steps.ts
+++ b/src/components/templates/MultistepFormPage/utils/steps.ts
@@ -6,8 +6,6 @@
 import { StepKey } from '@site/src/components/templates/MultistepFormPage/types';
 import { formSteps } from '@site/src/components/templates/MultistepFormPage/DataProvider';
 
-const BASE_URL = 'multistep-form-page';
-
 export const getNextStep = (step: StepKey) => {
   const index = formSteps.findIndex((s) => s.id === step);
   return formSteps[index + 1]?.id;
@@ -41,7 +39,7 @@ export const isFirstStep = (step: StepKey) => {
 };
 
 export const getStepUrl = (step: StepKey) => {
-  return `${BASE_URL}#${step}`;
+  return `#${step}`;
 };
 
 export const getActiveStep = () => {


### PR DESCRIPTION
This fixes 2 broken links:

- In the Patterns > Alert page it was linking to a component page we no longer have
- In the Templates > Multistep Form Page, the stepper links were being created as `/saga/templates/multistep-form-page/multistep-form-page/#additional`, so we don't need to pass in the BASE_URL for that link.