### PR TITLE
Saga: Add minimum version to latest components

### DIFF
--- a/docs/05-components/03-primitives/box.mdx
+++ b/docs/05-components/03-primitives/box.mdx
@@ -7,7 +7,7 @@ draft: false
 import { Box } from '@grafana/ui';
 
 # Box <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/general-layout-box--basic'/>
-_Minimum version: v10.2.3_
+_Available from v10.2.3_
 
 ## Overview
 

--- a/docs/05-components/03-primitives/box.mdx
+++ b/docs/05-components/03-primitives/box.mdx
@@ -7,6 +7,7 @@ draft: false
 import { Box } from '@grafana/ui';
 
 # Box <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/general-layout-box--basic'/>
+_Minimum version: v10.2.3_
 
 ## Overview
 

--- a/docs/05-components/03-primitives/grid.mdx
+++ b/docs/05-components/03-primitives/grid.mdx
@@ -7,7 +7,7 @@ draft: false
 import { Grid } from '@grafana/ui';
 
 # Grid <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/general-layout-grid--columns-number'/>
-_Minimum version: v10.2.3_
+_Available from v10.2.3_
 
 ## Overview
 

--- a/docs/05-components/03-primitives/grid.mdx
+++ b/docs/05-components/03-primitives/grid.mdx
@@ -7,6 +7,7 @@ draft: false
 import { Grid } from '@grafana/ui';
 
 # Grid <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/general-layout-grid--columns-number'/>
+_Minimum version: v10.2.3_
 
 ## Overview
 

--- a/docs/05-components/03-primitives/stack.mdx
+++ b/docs/05-components/03-primitives/stack.mdx
@@ -7,6 +7,7 @@ draft: false
 import { Stack } from '@grafana/ui';
 
 # Stack <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/general-layout-stack--basic'/>
+_Minimum version: v10.2.3_
 
 ## Overview
 

--- a/docs/05-components/03-primitives/stack.mdx
+++ b/docs/05-components/03-primitives/stack.mdx
@@ -7,7 +7,7 @@ draft: false
 import { Stack } from '@grafana/ui';
 
 # Stack <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/general-layout-stack--basic'/>
-_Minimum version: v10.2.3_
+_Available from v10.2.3_
 
 ## Overview
 

--- a/docs/06-patterns/empty-state.mdx
+++ b/docs/06-patterns/empty-state.mdx
@@ -4,7 +4,7 @@ description: Use an empty state to communicate to the user that there is no data
 ---
 
 # Empty State <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/general-emptystate--basic'/>
-_Minimum version: v11.0.0_
+_Available from v11.0.0_
 
 An empty state consists of a message and optionally an image, button, and additional information.
 

--- a/docs/06-patterns/empty-state.mdx
+++ b/docs/06-patterns/empty-state.mdx
@@ -4,6 +4,7 @@ description: Use an empty state to communicate to the user that there is no data
 ---
 
 # Empty State <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/general-emptystate--basic'/>
+_Minimum version: v11.0.0_
 
 An empty state consists of a message and optionally an image, button, and additional information.
 


### PR DESCRIPTION
We had a request about adding this information to each component: [Show compatible versions for each component in the Saga portal](https://github.com/grafana/grafana/issues/86993). As the majority of the components have been available for several versions, we decided to add this to the ones released from v10.0.0 on.

Fixes https://github.com/grafana/grafana/issues/86993 