### PR TITLE
Saga: Add the minimum version info to the component doc generator

### DIFF
--- a/scripts/templates/component.mdx.hbs
+++ b/scripts/templates/component.mdx.hbs
@@ -5,7 +5,7 @@ description: Grafana Labs {{componentName}} component
 
 # {{componentName}} <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/overlays-alert-toast--basic'/>
 _Available from vXX.X.X_ 
-(Specify the minimum version of Grafana in which the component is available. Needed for plugin devs.)
+{/* Specify the minimum version of Grafana in which the component is available. Needed for plugin devs.*/}
 
 ## Overview
 [//]: # (High-level description of the component)

--- a/scripts/templates/component.mdx.hbs
+++ b/scripts/templates/component.mdx.hbs
@@ -4,6 +4,8 @@ description: Grafana Labs {{componentName}} component
 ---
 
 # {{componentName}} <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/overlays-alert-toast--basic'/>
+_Available from vXX.X.X_ 
+(Specify the minimum version of Grafana in which the component is available. Needed for plugin devs.)
 
 ## Overview
 [//]: # (High-level description of the component)

--- a/scripts/templates/component.mdx.hbs
+++ b/scripts/templates/component.mdx.hbs
@@ -5,7 +5,7 @@ description: Grafana Labs {{componentName}} component
 
 # {{componentName}} <Badge text='ready' color='green'></Badge> <StorybookLink path='/story/overlays-alert-toast--basic'/>
 _Available from vXX.X.X_ 
-{/* Specify the minimum version of Grafana in which the component is available. Needed for plugin devs.*/}
+[//]: # (Specify the minimum version of Grafana in which the component is available. Needed for plugin devs.)
 
 ## Overview
 [//]: # (High-level description of the component)


### PR DESCRIPTION
We add the 'Available from vXX.X.X' in the component doc generator so, whenever a user generates the documentation, it will automatically added to the file.