### PR TITLE
Moving to rsync

### DIFF
--- a/.github/workflows/deploy-to-saga-dev.yml
+++ b/.github/workflows/deploy-to-saga-dev.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
@@ -33,9 +33,10 @@ jobs:
         uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY_DEV }}
-      - name: Deploy to Developer Portal Bucket
-        uses: google-github-actions/upload-cloud-storage@v2
-        with:
-          path: './build/'
-          destination: 'staging-developer-portal/saga'
-          parent: false
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+     
+      - name: 'Deploy to Developer Portal Bucket'
+        run: |
+          gsutil -m rsync -r -d -c -n ./docusaurus/website/build/ gs://staging-developer-portal/saga

--- a/.github/workflows/deploy-to-saga-dev.yml
+++ b/.github/workflows/deploy-to-saga-dev.yml
@@ -39,4 +39,4 @@ jobs:
      
       - name: 'Deploy to Developer Portal Bucket'
         run: |
-          gsutil -m rsync -r -d -c -n ./build/ gs://staging-developer-portal/saga
+          gsutil -m rsync -r -d -c ./build/ gs://staging-developer-portal/saga

--- a/.github/workflows/deploy-to-saga-dev.yml
+++ b/.github/workflows/deploy-to-saga-dev.yml
@@ -39,4 +39,4 @@ jobs:
      
       - name: 'Deploy to Developer Portal Bucket'
         run: |
-          gsutil -m rsync -r -d -c -n ./docusaurus/website/build/ gs://staging-developer-portal/saga
+          gsutil -m rsync -r -d -c -n ./build/ gs://staging-developer-portal/saga

--- a/.github/workflows/deploy-to-saga-prod.yml
+++ b/.github/workflows/deploy-to-saga-prod.yml
@@ -35,4 +35,4 @@ jobs:
      
       - name: 'Deploy to Developer Portal Bucket'
         run: |
-          gsutil -m rsync -r -d -c -n ./docusaurus/website/build/ gs://grafana-developer-portal/saga
+          gsutil -m rsync -r -d -c -n ./build/ gs://grafana-developer-portal/saga

--- a/.github/workflows/deploy-to-saga-prod.yml
+++ b/.github/workflows/deploy-to-saga-prod.yml
@@ -35,4 +35,4 @@ jobs:
      
       - name: 'Deploy to Developer Portal Bucket'
         run: |
-          gsutil -m rsync -r -d -c -n ./build/ gs://grafana-developer-portal/saga
+          gsutil -m rsync -r -d -c ./build/ gs://grafana-developer-portal/saga

--- a/.github/workflows/deploy-to-saga-prod.yml
+++ b/.github/workflows/deploy-to-saga-prod.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 
@@ -29,9 +29,10 @@ jobs:
         uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
-      - name: Deploy to Developer Portal Bucket
-        uses: google-github-actions/upload-cloud-storage@v2
-        with:
-          path: './build/'
-          destination: 'grafana-developer-portal/saga'
-          parent: false
+
+      - name: 'Set up Cloud SDK'
+        uses: 'google-github-actions/setup-gcloud@v2'
+     
+      - name: 'Deploy to Developer Portal Bucket'
+        run: |
+          gsutil -m rsync -r -d -c -n ./docusaurus/website/build/ gs://grafana-developer-portal/saga


### PR DESCRIPTION
Following up on: https://github.com/grafana/dataplane/pull/48, https://github.com/grafana/scenes/pull/938, https://github.com/grafana/plugin-tools/pull/1214 and https://github.com/grafana/grafana-developer-portal/pull/22

Switching to using rsync with delete option - to ensure that the GCS content equals the content of the build, up until now we just added new files but never deleted the old ones.  Since it is a static site - it can lead to some weird old built pages still being available even when deleted from the source code. This PR cleans it up.

Starting as dry run `-n` and will remove it before merge.

Example run for dev: https://github.com/grafana/design-system/actions/runs/11345469516

- [x] Remove dry run for dev
- [x] Remove dry run for prod